### PR TITLE
basic shablona cruft still remains in sphinx configs.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -87,17 +87,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/shablona.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/annsa.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/shablona.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/annsa.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/shablona"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/shablona"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/annsa"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/annsa"
 	@echo "# devhelp"
 
 epub:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -5,13 +5,13 @@ API
 Classes
 -------
 
-.. currentmodule:: shablona
+.. currentmodule:: annsa
 
 .. autosummary::
    :template: class.rst
    :toctree: gen_api
 
-   Model
+   DNN
 
 
 Functions
@@ -21,6 +21,4 @@ Functions
    :template: function.rst
    :toctree: gen_api
 
-   transform_data
-   cumgauss
-   opt_err_func
+   f1_error

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# shablona documentation build configuration file, created by
+# annsa documentation build configuration file, created by
 # sphinx-quickstart on Tue Apr 14 10:29:06 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -17,8 +17,8 @@ import sys
 import os
 
 # General information about the project.
-project = 'shablona'
-copyright = '2015, Ariel Rokem'
+project = 'annsa'
+copyright = '2019, Advanced Reactors and Fuel Cycles group'
 
 currentdir = os.path.abspath(os.path.dirname(__file__))
 ver_file = os.path.join(currentdir, '..', project, 'version.py')
@@ -76,7 +76,7 @@ sphinx_gallery_conf = {
     # path where to save gallery generated examples
     'gallery_dirs': 'auto_examples',
     # To auto-generate example sections in the API
-    'doc_module': ('shablona',),
+    'doc_module': ('annsa',),
     # Auto-generated mini-galleries go here
     'backreferences_dir': 'gen_api'
 }
@@ -216,7 +216,7 @@ html_domain_indices = False
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'shablonadoc'
+htmlhelp_basename = 'annsadoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -232,12 +232,12 @@ latex_elements = {
 #'preamble': '',
 }
 
-# Grouping the document tree into LaTeX files. List of tuples
+# grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'shablona.tex', 'shablona Documentation',
-   'Ariel Rokem', 'manual'),
+  ('index', 'annsa.tex', 'annsa Documentation',
+   'Advanced Reactors and Fuel Cycles group', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -266,8 +266,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'shablona', 'shablona Documentation',
-     ['Ariel Rokem'], 1)
+    ('index', 'annsa', 'annsa Documentation',
+     ['Advanced Reactors and Fuel Cycles group'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -276,13 +276,13 @@ man_pages = [
 
 # -- Options for Texinfo output -------------------------------------------
 
-# Grouping the document tree into Texinfo files. List of tuples
+# grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'shablona', 'shablona Documentation',
-   'Ariel Rokem', 'shablona', 'One line description of project.',
-   'Miscellaneous'),
+  ('index', 'annsa', 'annsa Documentation',
+   'Advanced Reactors and Fuel Cycles group', 'annsa', 'Artificial neural networks for spectral analysis.',
+   'Physics'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,12 +1,14 @@
-.. shablona documentation master file, created by sphinx-quickstart on Tue Apr 14 10:29:06 2015. You can adapt this file completely to your liking, but it should at least contain the root `toctree` directive.
+.. annsa documentation master file, created by sphinx-quickstart on Tue Apr 14 10:29:06 2015. You can adapt this file completely to your liking, but it should at least contain the root `toctree` directive.
 
-Welcome to shablona's documentation!
+Welcome to annsa's documentation!
 ====================================
 
-`Shablona` is a template for a small scientific Python project. 
+Artificial neural networks for spectroscopic analysis (`annsa`) is a python 
+package can quickly prototype gamma-ray spectra datasets and machine learning 
+and data science experiments for these datasets.
 
 To see how to use it, please refer to the `README file 
-<https://github.com/uwescience/shablona/blob/master/README.md>`_ in the Github repository.
+<https://github.com/annsa/annsa/blob/master/README.md>`_ in the Github repository.
 
 This is an example of documentation of the software, using sphinx_. 
 
@@ -18,6 +20,5 @@ Contents:
 .. toctree::
    :maxdepth: 2
 
-   theory
-   auto_examples/index
    api
+   theory


### PR DESCRIPTION
This gives you at least a vague start on #40. Search & replace from shablona to annsa. Changes api.rst to at least point to the right project.
The rest of #40 is mostly just pushing to github. (many examples, including [pyrk](https://github.com/pyrk/pyrk/blob/master/doc/Makefile) do this with fancy makefiles.)