### PR TITLE
updated CNN and DNN unit tests

### DIFF
--- a/annsa/model_classes.py
+++ b/annsa/model_classes.py
@@ -608,7 +608,6 @@ class DNN(tf.keras.Model, BaseClass):
 
         """
         x = self.scaler.transform(input_data)
-        x = tf.reshape(x, [-1, 1, x.shape[1]])
         for layer, nodes in enumerate(self.dense_nodes):
             x = self.dense_layers[str(layer)](x)
             x = self.drop_layers[str(layer)](x, training=training)

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -10,14 +10,16 @@ from annsa.model_classes import (generate_random_cnn1d_architecture,
 tf.enable_eager_execution()
 
 
-@pytest.fixture(params=[[], [10]])
+@pytest.fixture(params=[([],  0.5,),
+                        ([],  0.999,),
+                        ([10], 0.999)])
 def cnn1d(request):
     '''
     Constructs a convolutional neural network with filters
     initialized to ones. Fixture params are either zero or one hidden
     dense layer.
     '''
-    dense_nodes = request.param
+    dense_nodes, dropout_probability = request.param
 
     scaler = make_pipeline(FunctionTransformer(np.abs, validate=False))
     model_features = generate_random_cnn1d_architecture(
@@ -30,7 +32,7 @@ def cnn1d(request):
     model_features.output_size = 2
     model_features.output_function = None
     model_features.l2_regularization_scale = 1e1
-    model_features.dropout_probability = 0.999
+    model_features.dropout_probability = dropout_probability
     model_features.scaler = scaler
     model_features.Pooling = tf.layers.MaxPooling1D
     model_features.activation_function = None
@@ -56,7 +58,7 @@ def test_forward_pass_0(cnn1d):
     assert(output.shape[1] == 2)
 
 
-@pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
+@pytest.mark.parametrize('cnn1d', [([], 0.5)], indirect=True,)
 def test_forward_pass_1(cnn1d):
     '''case 1: Tests response to a spectrum of all ones
     when weight filters are all one. Note, layer before output has an
@@ -68,7 +70,7 @@ def test_forward_pass_1(cnn1d):
 
 
 # loss function tests
-@pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
+@pytest.mark.parametrize('cnn1d', [([], 0.5)], indirect=True,)
 def test_loss_fn_0(cnn1d):
     '''case 0: tests if l2 regularization does not add to the loss_fn
     with hidden dense layers.'''
@@ -81,7 +83,7 @@ def test_loss_fn_0(cnn1d):
     assert(loss == 0.)
 
 
-@pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
+@pytest.mark.parametrize('cnn1d', [([10], 0.5)], indirect=True,)
 def test_loss_fn_1(cnn1d):
     '''case 1: tests if l2 regularization adds to loss_fn when there are
     dense hidden layers.'''
@@ -95,7 +97,7 @@ def test_loss_fn_1(cnn1d):
 
 
 # dropout test
-@pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
+@pytest.mark.parametrize('cnn1d', [([], 0.999)], indirect=True,)
 def test_dropout_0(cnn1d):
     '''case 0: tests that dropout is not applied when there are no dense
     hidden layers.'''
@@ -106,7 +108,7 @@ def test_dropout_0(cnn1d):
     assert(np.array_equal(o_training_false, o_training_true))
 
 
-@pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
+@pytest.mark.parametrize('cnn1d', [([10], 0.999)], indirect=True,)
 def test_dropout_1(cnn1d):
     '''case 1: tests that dropout is applied when there are
     dense hidden layers'''
@@ -117,7 +119,7 @@ def test_dropout_1(cnn1d):
     assert(np.array_equal(o_training_false, o_training_true) is False)
 
 
-@pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
+@pytest.mark.parametrize('cnn1d', [([10], 0.999)], indirect=True,)
 def test_dropout_2(cnn1d):
     '''case 2: tests that dropout is not applied during inference, when
     training is False.'''

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -43,8 +43,8 @@ def cnn1d(request):
     # forward pass to initialize cnn1d weights
     model.forward_pass(np.ones([1, input_size]), training=False)
     # set weights to ones
-    weight_ones = [np.ones(weight.shape) if (index % 2 == 0) else weight for index,
-                   weight in enumerate(model.get_weights())]
+    weight_ones = [np.ones(weight.shape) if (index % 2 == 0) else weight for
+                   index, weight in enumerate(model.get_weights())]
     model.set_weights(weight_ones)
     return model
 

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -11,7 +11,7 @@ from annsa.model_classes import (generate_random_cnn1d_architecture,
 tf.enable_eager_execution()
 
 
-@pytest.fixture(params=[([],  0.5, 64),
+@pytest.fixture(params=[([10],  0.5, 64),
                         ([],  0.5, 1024),
                         ([],  0.999, 1024),
                         ([10], 0.999, 1024), ])
@@ -163,7 +163,7 @@ def test_dropout_2(cnn1d):
 # training tests
 @pytest.mark.parametrize('cost', ['mse', 'cross_entropy'])
 @pytest.mark.parametrize('cnn1d',
-                         (([],  0.5, 64),),
+                         (([10],  0.5, 64),),
                          indirect=True,)
 def test_training_0(cnn1d, toy_dataset, cost):
     '''case 0: test if training on toy dataset reduces errors using
@@ -174,9 +174,9 @@ def test_training_0(cnn1d, toy_dataset, cost):
         (data, targets_binarized),
         (data, targets_binarized),
         optimizer=tf.train.AdamOptimizer(1e-3),
-        num_epochs=2,
+        num_epochs=5,
         obj_cost=cost_function,
         data_augmentation=cnn1d.default_data_augmentation,)
     epoch0_error = objective_cost['test'][0].numpy()
-    epoch1_error = objective_cost['test'][1].numpy()
+    epoch1_error = objective_cost['test'][-1].numpy()
     assert(epoch1_error < epoch0_error)

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -124,5 +124,5 @@ def test_dropout_2(cnn1d):
     o_training_false_1 = cnn1d.forward_pass(np.ones([1, 1024]),
                                             training=False).numpy()
     o_training_false_2 = cnn1d.forward_pass(np.ones([1, 1024]),
-                                         training=False).numpy()
+                                            training=False).numpy()
     assert(np.array_equal(o_training_false_1, o_training_false_2))

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -4,7 +4,6 @@ import tensorflow as tf
 import pytest
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.pipeline import make_pipeline
-
 from annsa.model_classes import (generate_random_cnn1d_architecture,
                                  CNN1D)
 
@@ -49,7 +48,7 @@ def cnn1d(request):
     model.set_weights(weight_ones)
     return model
 
-
+# forward pass tests
 def test_forward_pass_0(cnn1d):
     '''case 0: test if output size is correct'''
     output = cnn1d.forward_pass(np.ones([1, 1024]), training=False)
@@ -83,7 +82,7 @@ def test_loss_fn_0(cnn1d):
 @pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
 def test_loss_fn_1(cnn1d):
     '''case 1: tests if l2 regularization adds to loss_fn when there are
-    dense nodes'''
+    dense hidden layers.'''
     loss = cnn1d.loss_fn(
         input_data=np.ones([1, 1024]),
         targets=np.array([[16384, 16384]]),
@@ -113,3 +112,13 @@ def test_dropout_2(cnn1d):
     o_training_true = cnn1d.forward_pass(np.ones([1, 1024]),
                                          training=True).numpy()
     assert(np.array_equal(o_training_false, o_training_true) is False)
+    
+@pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
+def test_dropout_2(cnn1d):
+    '''case 0: tests that dropout is not applied during inference, when
+    training is False.'''
+    o_training_false_1 = cnn1d.forward_pass(np.ones([1, 1024]),
+                                          training=False).numpy()
+    o_training_false_2 = cnn1d.forward_pass(np.ones([1, 1024]),
+                                         training=False).numpy()
+    assert(np.array_equal(o_training_false_1, o_training_false_2))

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -43,12 +43,8 @@ def cnn1d(request):
     # forward pass to initialize cnn1d weights
     model.forward_pass(np.ones([1, input_size]), training=False)
     # set weights to ones
-    weight_ones = []
-    for index, weight in enumerate(model.get_weights()):
-        if index % 2 == 0:
-            weight_ones.append(np.ones(weight.shape))
-        else:
-            weight_ones.append(weight)
+    weight_ones = [np.ones(weight.shape) if (index % 2 == 0) else weight for index,
+                   weight in enumerate(model.get_weights())]
     model.set_weights(weight_ones)
     return model
 

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -14,7 +14,7 @@ tf.enable_eager_execution()
 @pytest.fixture(params=[([],  0.5, 64),
                         ([],  0.5, 1024),
                         ([],  0.999, 1024),
-                        ([10], 0.999, 1024),])
+                        ([10], 0.999, 1024), ])
 def cnn1d(request):
     '''
     Constructs a convolutional neural network with filters
@@ -67,8 +67,8 @@ def toy_dataset():
 # forward pass tests
 @pytest.mark.parametrize('cnn1d',
                          (([],  0.5, 1024),
-                         ([],  0.999, 1024),
-                         ([10], 0.999, 1024)),
+                          ([],  0.999, 1024),
+                          ([10], 0.999, 1024)),
                          indirect=True,)
 def test_forward_pass_0(cnn1d):
     '''case 0: test if output size is correct'''
@@ -166,7 +166,7 @@ def test_dropout_2(cnn1d):
                          (([],  0.5, 64),),
                          indirect=True,)
 def test_training_0(cnn1d, toy_dataset, cost):
-    '''case 0: test if training on toy dataset reduces errors using 
+    '''case 0: test if training on toy dataset reduces errors using
     both error functions'''
     (data, targets_binarized) = toy_dataset
     cost_function = getattr(cnn1d, cost)

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -5,8 +5,7 @@ import pytest
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.pipeline import make_pipeline
 
-from annsa.model_classes import (BaseClass,
-                                 generate_random_cnn1d_architecture,
+from annsa.model_classes import (generate_random_cnn1d_architecture,
                                  CNN1D)
 
 tf.enable_eager_execution()
@@ -20,7 +19,7 @@ def cnn1d(request):
     dense layer.
     '''
     dense_nodes = request.param
-    
+
     scaler = make_pipeline(FunctionTransformer(np.abs, validate=False))
     model_features = generate_random_cnn1d_architecture(
         cnn_filters_choices=((4, 1),),
@@ -73,19 +72,20 @@ def test_loss_fn_0(cnn1d):
     '''case 0: tests if l2 regularization does not add to the loss_fn
     with hidden dense layers.'''
     loss = cnn1d.loss_fn(
-        input_data=np.ones([1,1024]),
+        input_data=np.ones([1, 1024]),
         targets=np.array([[16384, 16384]]),
         cost=cnn1d.mse,
         training=False)
     loss = loss.numpy()
     assert(loss == 0.)
 
+
 @pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
 def test_loss_fn_1(cnn1d):
     '''case 1: tests if l2 regularization adds to loss_fn when there are
     dense nodes'''
     loss = cnn1d.loss_fn(
-        input_data=np.ones([1,1024]),
+        input_data=np.ones([1, 1024]),
         targets=np.array([[16384, 16384]]),
         cost=cnn1d.mse,
         training=False)
@@ -95,20 +95,21 @@ def test_loss_fn_1(cnn1d):
 # dropout test
 @pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
 def test_dropout_1(cnn1d):
-    '''case 0: tests that dropout is not applied when there are no dense 
+    '''case 0: tests that dropout is not applied when there are no dense
     hidden layers.'''
-    o_training_false = cnn1d.forward_pass(np.ones([1,1024]),
-                                               training=False).numpy()
-    o_training_true = cnn1d.forward_pass(np.ones([1,1024]),
-                                             training=True).numpy()
+    o_training_false = cnn1d.forward_pass(np.ones([1, 1024]),
+                                          training=False).numpy()
+    o_training_true = cnn1d.forward_pass(np.ones([1, 1024]),
+                                         training=True).numpy()
     assert(np.array_equal(o_training_false, o_training_true))
+
 
 @pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
 def test_dropout_2(cnn1d):
-    '''case 0: tests that dropout is applied when there are dense hidden layers'''
-    o_training_false = cnn1d.forward_pass(np.ones([1,1024]),
-                                               training=False).numpy()
-    o_training_true = cnn1d.forward_pass(np.ones([1,1024]),
-                                             training=True).numpy()
+    '''case 0: tests that dropout is applied when there are
+    dense hidden layers'''
+    o_training_false = cnn1d.forward_pass(np.ones([1, 1024]),
+                                          training=False).numpy()
+    o_training_true = cnn1d.forward_pass(np.ones([1, 1024]),
+                                         training=True).numpy()
     assert(np.array_equal(o_training_false, o_training_true) is False)
-    

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -30,7 +30,7 @@ def cnn1d(request):
     model_features.output_size = 2
     model_features.output_function = None
     model_features.l2_regularization_scale = 1e1
-    model_features.dropout_probability = 0.5
+    model_features.dropout_probability = 0.999
     model_features.scaler = scaler
     model_features.Pooling = tf.layers.MaxPooling1D
     model_features.activation_function = None
@@ -124,5 +124,5 @@ def test_dropout_2(cnn1d):
     o_training_false_1 = cnn1d.forward_pass(np.ones([1, 1024]),
                                             training=False).numpy()
     o_training_false_2 = cnn1d.forward_pass(np.ones([1, 1024]),
-                                            training=False).numpy()
+                                         training=False).numpy()
     assert(np.array_equal(o_training_false_1, o_training_false_2))

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -37,7 +37,7 @@ def cnn1d(request):
     model_features.dense_nodes = dense_nodes
     model = CNN1D(model_features)
     # forward pass to initialize cnn1d weights
-    model.forward_pass(1*np.ones([1, 1024]), training=False)
+    model.forward_pass(np.ones([1, 1024]), training=False)
     # set weights to ones
     weight_ones = []
     for index, weight in enumerate(model.get_weights()):
@@ -47,6 +47,7 @@ def cnn1d(request):
             weight_ones.append(weight)
     model.set_weights(weight_ones)
     return model
+
 
 # forward pass tests
 def test_forward_pass_0(cnn1d):
@@ -64,6 +65,7 @@ def test_forward_pass_1(cnn1d):
     output = cnn1d.forward_pass(np.ones([1, 1024]), training=False)
     output_value = output.numpy()[0][0]
     assert(output_value == 16384)
+
 
 # loss function tests
 @pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
@@ -91,9 +93,10 @@ def test_loss_fn_1(cnn1d):
     loss = loss
     assert(loss > 0.)
 
+
 # dropout test
 @pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
-def test_dropout_1(cnn1d):
+def test_dropout_0(cnn1d):
     '''case 0: tests that dropout is not applied when there are no dense
     hidden layers.'''
     o_training_false = cnn1d.forward_pass(np.ones([1, 1024]),
@@ -104,21 +107,22 @@ def test_dropout_1(cnn1d):
 
 
 @pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
-def test_dropout_2(cnn1d):
-    '''case 0: tests that dropout is applied when there are
+def test_dropout_1(cnn1d):
+    '''case 1: tests that dropout is applied when there are
     dense hidden layers'''
     o_training_false = cnn1d.forward_pass(np.ones([1, 1024]),
                                           training=False).numpy()
     o_training_true = cnn1d.forward_pass(np.ones([1, 1024]),
                                          training=True).numpy()
     assert(np.array_equal(o_training_false, o_training_true) is False)
-    
+
+
 @pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
 def test_dropout_2(cnn1d):
-    '''case 0: tests that dropout is not applied during inference, when
+    '''case 2: tests that dropout is not applied during inference, when
     training is False.'''
     o_training_false_1 = cnn1d.forward_pass(np.ones([1, 1024]),
-                                          training=False).numpy()
+                                            training=False).numpy()
     o_training_false_2 = cnn1d.forward_pass(np.ones([1, 1024]),
-                                         training=False).numpy()
+                                            training=False).numpy()
     assert(np.array_equal(o_training_false_1, o_training_false_2))

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -2,24 +2,26 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import tensorflow as tf
 import pytest
-from sklearn.preprocessing import FunctionTransformer
+from sklearn.preprocessing import FunctionTransformer, LabelBinarizer
 from sklearn.pipeline import make_pipeline
+from sklearn.datasets import load_digits
 from annsa.model_classes import (generate_random_cnn1d_architecture,
                                  CNN1D)
 
 tf.enable_eager_execution()
 
 
-@pytest.fixture(params=[([],  0.5,),
-                        ([],  0.999,),
-                        ([10], 0.999)])
+@pytest.fixture(params=[([],  0.5, 64),
+                        ([],  0.5, 1024),
+                        ([],  0.999, 1024),
+                        ([10], 0.999, 1024),])
 def cnn1d(request):
     '''
     Constructs a convolutional neural network with filters
     initialized to ones. Fixture params are either zero or one hidden
     dense layer.
     '''
-    dense_nodes, dropout_probability = request.param
+    (dense_nodes, dropout_probability, input_size) = request.param
 
     scaler = make_pipeline(FunctionTransformer(np.abs, validate=False))
     model_features = generate_random_cnn1d_architecture(
@@ -28,8 +30,8 @@ def cnn1d(request):
         pool_size_choices=((4, ), ))
     model_features.learning_rate = 1e-1
     model_features.trainable = True
-    model_features.batch_size = 2**5
-    model_features.output_size = 2
+    model_features.batch_size = 5
+    model_features.output_size = 3
     model_features.output_function = None
     model_features.l2_regularization_scale = 1e1
     model_features.dropout_probability = dropout_probability
@@ -39,7 +41,7 @@ def cnn1d(request):
     model_features.dense_nodes = dense_nodes
     model = CNN1D(model_features)
     # forward pass to initialize cnn1d weights
-    model.forward_pass(np.ones([1, 1024]), training=False)
+    model.forward_pass(np.ones([1, input_size]), training=False)
     # set weights to ones
     weight_ones = []
     for index, weight in enumerate(model.get_weights()):
@@ -51,14 +53,32 @@ def cnn1d(request):
     return model
 
 
+@pytest.fixture()
+def toy_dataset():
+    '''
+    Constructs toy dataset of digits.
+    '''
+    data, target = load_digits(n_class=3, return_X_y=True)
+    mlb = LabelBinarizer()
+    targets_binarized = mlb.fit_transform(target)
+    return (data, targets_binarized)
+
+
 # forward pass tests
+@pytest.mark.parametrize('cnn1d',
+                         (([],  0.5, 1024),
+                         ([],  0.999, 1024),
+                         ([10], 0.999, 1024)),
+                         indirect=True,)
 def test_forward_pass_0(cnn1d):
     '''case 0: test if output size is correct'''
     output = cnn1d.forward_pass(np.ones([1, 1024]), training=False)
-    assert(output.shape[1] == 2)
+    assert(output.shape[1] == 3)
 
 
-@pytest.mark.parametrize('cnn1d', [([], 0.5)], indirect=True,)
+@pytest.mark.parametrize('cnn1d',
+                         (([],  0.5, 1024),),
+                         indirect=True,)
 def test_forward_pass_1(cnn1d):
     '''case 1: Tests response to a spectrum of all ones
     when weight filters are all one. Note, layer before output has an
@@ -70,26 +90,30 @@ def test_forward_pass_1(cnn1d):
 
 
 # loss function tests
-@pytest.mark.parametrize('cnn1d', [([], 0.5)], indirect=True,)
+@pytest.mark.parametrize('cnn1d',
+                         (([],  0.5, 1024),),
+                         indirect=True,)
 def test_loss_fn_0(cnn1d):
     '''case 0: tests if l2 regularization does not add to the loss_fn
     with hidden dense layers.'''
     loss = cnn1d.loss_fn(
         input_data=np.ones([1, 1024]),
-        targets=np.array([[16384, 16384]]),
+        targets=np.array([[16384, 16384, 16384]]),
         cost=cnn1d.mse,
         training=False)
     loss = loss.numpy()
     assert(loss == 0.)
 
 
-@pytest.mark.parametrize('cnn1d', [([10], 0.5)], indirect=True,)
+@pytest.mark.parametrize('cnn1d',
+                         (([10], 0.999, 1024),),
+                         indirect=True,)
 def test_loss_fn_1(cnn1d):
     '''case 1: tests if l2 regularization adds to loss_fn when there are
     dense hidden layers.'''
     loss = cnn1d.loss_fn(
         input_data=np.ones([1, 1024]),
-        targets=np.array([[16384, 16384]]),
+        targets=np.array([[16384, 16384, 16384]]),
         cost=cnn1d.mse,
         training=False)
     loss = loss
@@ -97,7 +121,9 @@ def test_loss_fn_1(cnn1d):
 
 
 # dropout test
-@pytest.mark.parametrize('cnn1d', [([], 0.999)], indirect=True,)
+@pytest.mark.parametrize('cnn1d',
+                         (([],  0.999, 1024),),
+                         indirect=True,)
 def test_dropout_0(cnn1d):
     '''case 0: tests that dropout is not applied when there are no dense
     hidden layers.'''
@@ -108,7 +134,9 @@ def test_dropout_0(cnn1d):
     assert(np.array_equal(o_training_false, o_training_true))
 
 
-@pytest.mark.parametrize('cnn1d', [([10], 0.999)], indirect=True,)
+@pytest.mark.parametrize('cnn1d',
+                         (([10], 0.999, 1024),),
+                         indirect=True,)
 def test_dropout_1(cnn1d):
     '''case 1: tests that dropout is applied when there are
     dense hidden layers'''
@@ -119,7 +147,9 @@ def test_dropout_1(cnn1d):
     assert(np.array_equal(o_training_false, o_training_true) is False)
 
 
-@pytest.mark.parametrize('cnn1d', [([10], 0.999)], indirect=True,)
+@pytest.mark.parametrize('cnn1d',
+                         (([10], 0.999, 1024),),
+                         indirect=True,)
 def test_dropout_2(cnn1d):
     '''case 2: tests that dropout is not applied during inference, when
     training is False.'''
@@ -128,3 +158,25 @@ def test_dropout_2(cnn1d):
     o_training_false_2 = cnn1d.forward_pass(np.ones([1, 1024]),
                                             training=False).numpy()
     assert(np.array_equal(o_training_false_1, o_training_false_2))
+
+
+# training tests
+@pytest.mark.parametrize('cost', ['mse', 'cross_entropy'])
+@pytest.mark.parametrize('cnn1d',
+                         (([],  0.5, 64),),
+                         indirect=True,)
+def test_training_0(cnn1d, toy_dataset, cost):
+    '''case 0: test if training on toy dataset reduces errors using 
+    both error functions'''
+    (data, targets_binarized) = toy_dataset
+    cost_function = getattr(cnn1d, cost)
+    objective_cost, earlystop_cost = cnn1d.fit_batch(
+        (data, targets_binarized),
+        (data, targets_binarized),
+        optimizer=tf.train.AdamOptimizer(1e-3),
+        num_epochs=2,
+        obj_cost=cost_function,
+        data_augmentation=cnn1d.default_data_augmentation,)
+    epoch0_error = objective_cost['test'][0].numpy()
+    epoch1_error = objective_cost['test'][1].numpy()
+    assert(epoch1_error < epoch0_error)

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -11,9 +11,9 @@ from annsa.model_classes import (generate_random_cnn1d_architecture,
 tf.enable_eager_execution()
 
 
-@pytest.fixture(params=[([10],  0.5, 64),
-                        ([],  0.5, 1024),
-                        ([],  0.999, 1024),
+@pytest.fixture(params=[([10], 0.5, 64),
+                        ([], 0.5, 1024),
+                        ([], 0.999, 1024),
                         ([10], 0.999, 1024), ])
 def cnn1d(request):
     '''
@@ -66,8 +66,8 @@ def toy_dataset():
 
 # forward pass tests
 @pytest.mark.parametrize('cnn1d',
-                         (([],  0.5, 1024),
-                          ([],  0.999, 1024),
+                         (([], 0.5, 1024),
+                          ([], 0.999, 1024),
                           ([10], 0.999, 1024)),
                          indirect=True,)
 def test_forward_pass_0(cnn1d):
@@ -77,7 +77,7 @@ def test_forward_pass_0(cnn1d):
 
 
 @pytest.mark.parametrize('cnn1d',
-                         (([],  0.5, 1024),),
+                         (([], 0.5, 1024),),
                          indirect=True,)
 def test_forward_pass_1(cnn1d):
     '''case 1: Tests response to a spectrum of all ones
@@ -91,7 +91,7 @@ def test_forward_pass_1(cnn1d):
 
 # loss function tests
 @pytest.mark.parametrize('cnn1d',
-                         (([],  0.5, 1024),),
+                         (([], 0.5, 1024),),
                          indirect=True,)
 def test_loss_fn_0(cnn1d):
     '''case 0: tests if l2 regularization does not add to the loss_fn
@@ -122,7 +122,7 @@ def test_loss_fn_1(cnn1d):
 
 # dropout test
 @pytest.mark.parametrize('cnn1d',
-                         (([],  0.999, 1024),),
+                         (([], 0.999, 1024),),
                          indirect=True,)
 def test_dropout_0(cnn1d):
     '''case 0: tests that dropout is not applied when there are no dense
@@ -163,7 +163,7 @@ def test_dropout_2(cnn1d):
 # training tests
 @pytest.mark.parametrize('cost', ['mse', 'cross_entropy'])
 @pytest.mark.parametrize('cnn1d',
-                         (([10],  0.5, 64),),
+                         (([10], 0.5, 64),),
                          indirect=True,)
 def test_training_0(cnn1d, toy_dataset, cost):
     '''case 0: test if training on toy dataset reduces errors using
@@ -174,7 +174,7 @@ def test_training_0(cnn1d, toy_dataset, cost):
         (data, targets_binarized),
         (data, targets_binarized),
         optimizer=tf.train.AdamOptimizer(1e-3),
-        num_epochs=5,
+        num_epochs=2,
         obj_cost=cost_function,
         data_augmentation=cnn1d.default_data_augmentation,)
     epoch0_error = objective_cost['test'][0].numpy()

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -11,15 +11,21 @@ from annsa.model_classes import (BaseClass,
 
 tf.enable_eager_execution()
 
-@pytest.fixture(scope)
-def cnn1d():
+
+@pytest.fixture(params=[[], [10]])
+def cnn1d(request):
     '''
-    Constructs a convolutional neural network with random filter initialization.
+    Constructs a convolutional neural network with filters
+    initialized to ones. Fixture params are either zero or one hidden
+    dense layer.
     '''
+    dense_nodes = request.param
+    
     scaler = make_pipeline(FunctionTransformer(np.abs, validate=False))
-    model_features = generate_random_cnn1d_architecture(cnn_filters_choices=((4, 1),),
-                                                        cnn_kernel_choices=((4,),),
-                                                        pool_size_choices=((4,),))
+    model_features = generate_random_cnn1d_architecture(
+        cnn_filters_choices=((4, 1),),
+        cnn_kernel_choices=((4, ), ),
+        pool_size_choices=((4, ), ))
     model_features.learning_rate = 1e-1
     model_features.trainable = True
     model_features.batch_size = 2**5
@@ -30,119 +36,79 @@ def cnn1d():
     model_features.scaler = scaler
     model_features.Pooling = tf.layers.MaxPooling1D
     model_features.activation_function = None
-    model_features.dense_nodes = []
+    model_features.dense_nodes = dense_nodes
     model = CNN1D(model_features)
-    # forwward pass to initialize cnn1d weights
-    model.forward_pass(1*np.ones([1,1024]), training=False)
-    return model
-
-@pytest.fixture()
-def cnn1d_ones():
-    '''
-    Constructs a convolutional neural network and replaces filters with ones.
-    '''
+    # forward pass to initialize cnn1d weights
+    model.forward_pass(1*np.ones([1, 1024]), training=False)
+    # set weights to ones
     weight_ones = []
-    for index, weight in enumerate(cnn1d.get_weights()):
-        if index %2 == 0:
+    for index, weight in enumerate(model.get_weights()):
+        if index % 2 == 0:
             weight_ones.append(np.ones(weight.shape))
         else:
             weight_ones.append(weight)
-    cnn1d.set_weights(weight_ones)
+    model.set_weights(weight_ones)
+    return model
 
-    return cnn1d
 
-# forward pass tests
 def test_forward_pass_0(cnn1d):
     '''case 0: test if output size is correct'''
-    output = cnn1d.forward_pass(np.ones([1,1024]), training=False)
+    output = cnn1d.forward_pass(np.ones([1, 1024]), training=False)
     assert(output.shape[1] == 2)
 
-def test_forward_pass_1(cnn1d_ones):
+
+@pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
+def test_forward_pass_1(cnn1d):
     '''case 1: Tests response to a spectrum of all ones
-    when weight filters are all one. Note, layer before output has an 
+    when weight filters are all one. Note, layer before output has an
     activation of 64 in each node and a length of 256. Densely connected
     output connection yields 64*256=16384 for each output node.'''
-    output = cnn1d_ones.forward_pass(np.ones([1,1024]), training=False)
-    output_node = output.numpy()[0][0]
-    assert(output_node == 16384)
+    output = cnn1d.forward_pass(np.ones([1, 1024]), training=False)
+    output_value = output.numpy()[0][0]
+    assert(output_value == 16384)
 
 # loss function tests
-
-@pytest.mark.parametrize('name', ['Claire', 'Gloria', 'Haley'])
-def test_loss_fn_0(cnn1d_ones(dense_nodes)):
-    '''case 0: tests if mse cost function works with cnn1d'''
-    loss = cnn1d_ones.loss_fn(
+@pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
+def test_loss_fn_0(cnn1d):
+    '''case 0: tests if l2 regularization does not add to the loss_fn
+    with hidden dense layers.'''
+    loss = cnn1d.loss_fn(
         input_data=np.ones([1,1024]),
         targets=np.array([[16384, 16384]]),
-        cost=cnn1d_ones.mse,
+        cost=cnn1d.mse,
         training=False)
-    loss = loss.numpy()
-    if True
-        assert(loss == 0.)
-    if False
-        assert(loss != 0.)
-
-# def test_loss_fn_1(cnn1d):
-#     '''case 1: tests if l2 regularization .'''
-#     loss = cnn1d_ones.loss_fn(
-#         input_data=np.ones([1,1024]),
-#         targets=np.array([[16384, 16384]]),
-#         cost=cnn1d_ones.mse,
-#         training=True)
-#     loss = loss.numpy()
-#     assert(loss == 0.)
-    
-def test_loss_fn_1(cnn1d(dense_nodes = [10])):
-    '''case 0: tests if l2 regularization adds to loss_fn when there are dense nodes'''
-    loss = cnn1d_ones.loss_fn(
-        input_data=np.ones([1,1024]),
-        targets=np.array([[16384, 16384]]),
-        cost=cnn1d_ones.mse,
-        training=True)
     loss = loss.numpy()
     assert(loss == 0.)
 
+@pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
+def test_loss_fn_1(cnn1d):
+    '''case 1: tests if l2 regularization adds to loss_fn when there are
+    dense nodes'''
+    loss = cnn1d.loss_fn(
+        input_data=np.ones([1,1024]),
+        targets=np.array([[16384, 16384]]),
+        cost=cnn1d.mse,
+        training=False)
+    loss = loss
+    assert(loss > 0.)
+
+# dropout test
+@pytest.mark.parametrize('cnn1d', [[]], indirect=True,)
+def test_dropout_1(cnn1d):
+    '''case 0: tests that dropout is not applied when there are no dense 
+    hidden layers.'''
+    o_training_false = cnn1d.forward_pass(np.ones([1,1024]),
+                                               training=False).numpy()
+    o_training_true = cnn1d.forward_pass(np.ones([1,1024]),
+                                             training=True).numpy()
+    assert(np.array_equal(o_training_false, o_training_true))
+
+@pytest.mark.parametrize('cnn1d', [[10]], indirect=True,)
+def test_dropout_2(cnn1d):
+    '''case 0: tests that dropout is applied when there are dense hidden layers'''
+    o_training_false = cnn1d.forward_pass(np.ones([1,1024]),
+                                               training=False).numpy()
+    o_training_true = cnn1d.forward_pass(np.ones([1,1024]),
+                                             training=True).numpy()
+    assert(np.array_equal(o_training_false, o_training_true) is False)
     
-# # dropout test
-# @pytest.mark.parametrize('dense_nodes, output', [([], [10]),
-#                                                  (True, False)])
-# def test_dropout_1(cnn1d):
-#     '''case 0: tests that dropout is not applied when there are no dense layers'''
-#     o_training_false = cnn1d_ones.forward_pass(np.ones([1,1024]),
-#                                                training=False).numpy()
-#     o_training_true = cnn1d_ones.forward_pass(np.ones([1,1024]),
-#                                              training=True).numpy()
-#     assert(o_training_false == o_training_true)
-
-# def test_dropout_2(cnn1d(dense_nodes = [10]):
-#     '''case 0: tests that dropout is not applied when there are no dense layers'''
-#     o_training_false = cnn1d_ones.forward_pass(np.ones([1,1024]),
-#                                                training=False).numpy()
-#     o_training_true = cnn1d_ones.forward_pass(np.ones([1,1024]),
-#                                              training=True).numpy()
-#     assert(o_training_false != o_training_true)
-    
-# def test_cnn1d_training():
-#     """
-#     Testing the convolutional neural network class and training function.
-
-#     Returns : Nothing
-#     """
-
-#     tf.reset_default_graph()
-#     model_features, optimizer, model = construct_cnn1d()
-#     train_dataset, test_dataset = load_dataset()
-#     model_features.scaler.fit(train_dataset[0])
-
-#     all_loss_train, all_loss_test = model.fit_batch(
-#         train_dataset,
-#         test_dataset,
-#         optimizer,
-#         num_epochs=1,
-#         earlystop_patience=0,
-#         verbose=1,
-#         print_errors=0,
-#         obj_cost=model.cross_entropy,
-#         earlystop_cost_fn=model.f1_error,
-#         data_augmentation=model.default_data_augmentation,)
-#     pass

--- a/annsa/tests/test_training_cnn1d.py
+++ b/annsa/tests/test_training_cnn1d.py
@@ -1,92 +1,148 @@
 from __future__ import absolute_import, division, print_function
 import numpy as np
 import tensorflow as tf
-
+import pytest
 from sklearn.preprocessing import FunctionTransformer
 from sklearn.pipeline import make_pipeline
 
-from annsa.model_classes import (generate_random_cnn1d_architecture,
+from annsa.model_classes import (BaseClass,
+                                 generate_random_cnn1d_architecture,
                                  CNN1D)
-from annsa.load_dataset import load_dataset
 
 tf.enable_eager_execution()
 
-
-def construct_cnn1d():
-    """
-    Constructs a convolutional neural network and tests construction
-    functions.
-
-    Returns:
-    --------
-    model_features : class cnn1d_model_features
-        Contains all features of the CNN1D model
-
-    optimizer :
-    An Operation that updates the variables in var_list.
-    If global_step was not None, that operation also increments
-    global_step. See documentation for tf.train.Optimizer
-
-    model : Class CNN1D
-        A convolution neural network for finding one dimensional
-        features.
-    """
-    scaler = make_pipeline(FunctionTransformer(np.log1p, validate=False))
-
-    cnn_filters_choices = ((4, 1), (8, 1))  # choose either 4x1 or 8x1 filter.
-    cnn_kernel_choices = ((8, ), (4, ))  # choose either 8xn or 4xn kernel size.
-    pool_size_choices = ((8, ), (4, ))
-    model_features = generate_random_cnn1d_architecture(cnn_filters_choices,
-                                                        cnn_kernel_choices,
-                                                        pool_size_choices,)
+@pytest.fixture(scope)
+def cnn1d():
+    '''
+    Constructs a convolutional neural network with random filter initialization.
+    '''
+    scaler = make_pipeline(FunctionTransformer(np.abs, validate=False))
+    model_features = generate_random_cnn1d_architecture(cnn_filters_choices=((4, 1),),
+                                                        cnn_kernel_choices=((4,),),
+                                                        pool_size_choices=((4,),))
     model_features.learning_rate = 1e-1
     model_features.trainable = True
     model_features.batch_size = 2**5
     model_features.output_size = 2
     model_features.output_function = None
-    model_features.l2_regularization_scale = 1e-1
+    model_features.l2_regularization_scale = 1e1
     model_features.dropout_probability = 0.5
     model_features.scaler = scaler
     model_features.Pooling = tf.layers.MaxPooling1D
-    model_features.activation_function = tf.nn.relu
-
-    optimizer = tf.train.AdamOptimizer(model_features.learning_rate)
+    model_features.activation_function = None
+    model_features.dense_nodes = []
     model = CNN1D(model_features)
-    return model_features, optimizer, model
+    # forwward pass to initialize cnn1d weights
+    model.forward_pass(1*np.ones([1,1024]), training=False)
+    return model
 
+@pytest.fixture()
+def cnn1d_ones():
+    '''
+    Constructs a convolutional neural network and replaces filters with ones.
+    '''
+    weight_ones = []
+    for index, weight in enumerate(cnn1d.get_weights()):
+        if index %2 == 0:
+            weight_ones.append(np.ones(weight.shape))
+        else:
+            weight_ones.append(weight)
+    cnn1d.set_weights(weight_ones)
 
-def test_cnn1d_construction():
-    """
-    Tests the construction of a convolution neural network.
+    return cnn1d
 
-    Returns: Nothing
+# forward pass tests
+def test_forward_pass_0(cnn1d):
+    '''case 0: test if output size is correct'''
+    output = cnn1d.forward_pass(np.ones([1,1024]), training=False)
+    assert(output.shape[1] == 2)
 
-    """
-    _, _, _ = construct_cnn1d()
-    pass
+def test_forward_pass_1(cnn1d_ones):
+    '''case 1: Tests response to a spectrum of all ones
+    when weight filters are all one. Note, layer before output has an 
+    activation of 64 in each node and a length of 256. Densely connected
+    output connection yields 64*256=16384 for each output node.'''
+    output = cnn1d_ones.forward_pass(np.ones([1,1024]), training=False)
+    output_node = output.numpy()[0][0]
+    assert(output_node == 16384)
 
+# loss function tests
 
-def test_cnn1d_training():
-    """
-    Testing the convolutional neural network class and training function.
+@pytest.mark.parametrize('name', ['Claire', 'Gloria', 'Haley'])
+def test_loss_fn_0(cnn1d_ones(dense_nodes)):
+    '''case 0: tests if mse cost function works with cnn1d'''
+    loss = cnn1d_ones.loss_fn(
+        input_data=np.ones([1,1024]),
+        targets=np.array([[16384, 16384]]),
+        cost=cnn1d_ones.mse,
+        training=False)
+    loss = loss.numpy()
+    if True
+        assert(loss == 0.)
+    if False
+        assert(loss != 0.)
 
-    Returns : Nothing
-    """
+# def test_loss_fn_1(cnn1d):
+#     '''case 1: tests if l2 regularization .'''
+#     loss = cnn1d_ones.loss_fn(
+#         input_data=np.ones([1,1024]),
+#         targets=np.array([[16384, 16384]]),
+#         cost=cnn1d_ones.mse,
+#         training=True)
+#     loss = loss.numpy()
+#     assert(loss == 0.)
+    
+def test_loss_fn_1(cnn1d(dense_nodes = [10])):
+    '''case 0: tests if l2 regularization adds to loss_fn when there are dense nodes'''
+    loss = cnn1d_ones.loss_fn(
+        input_data=np.ones([1,1024]),
+        targets=np.array([[16384, 16384]]),
+        cost=cnn1d_ones.mse,
+        training=True)
+    loss = loss.numpy()
+    assert(loss == 0.)
 
-    tf.reset_default_graph()
-    model_features, optimizer, model = construct_cnn1d()
-    train_dataset, test_dataset = load_dataset()
-    model_features.scaler.fit(train_dataset[0])
+    
+# # dropout test
+# @pytest.mark.parametrize('dense_nodes, output', [([], [10]),
+#                                                  (True, False)])
+# def test_dropout_1(cnn1d):
+#     '''case 0: tests that dropout is not applied when there are no dense layers'''
+#     o_training_false = cnn1d_ones.forward_pass(np.ones([1,1024]),
+#                                                training=False).numpy()
+#     o_training_true = cnn1d_ones.forward_pass(np.ones([1,1024]),
+#                                              training=True).numpy()
+#     assert(o_training_false == o_training_true)
 
-    all_loss_train, all_loss_test = model.fit_batch(
-        train_dataset,
-        test_dataset,
-        optimizer,
-        num_epochs=1,
-        earlystop_patience=0,
-        verbose=1,
-        print_errors=0,
-        obj_cost=model.cross_entropy,
-        earlystop_cost_fn=model.f1_error,
-        data_augmentation=model.default_data_augmentation,)
-    pass
+# def test_dropout_2(cnn1d(dense_nodes = [10]):
+#     '''case 0: tests that dropout is not applied when there are no dense layers'''
+#     o_training_false = cnn1d_ones.forward_pass(np.ones([1,1024]),
+#                                                training=False).numpy()
+#     o_training_true = cnn1d_ones.forward_pass(np.ones([1,1024]),
+#                                              training=True).numpy()
+#     assert(o_training_false != o_training_true)
+    
+# def test_cnn1d_training():
+#     """
+#     Testing the convolutional neural network class and training function.
+
+#     Returns : Nothing
+#     """
+
+#     tf.reset_default_graph()
+#     model_features, optimizer, model = construct_cnn1d()
+#     train_dataset, test_dataset = load_dataset()
+#     model_features.scaler.fit(train_dataset[0])
+
+#     all_loss_train, all_loss_test = model.fit_batch(
+#         train_dataset,
+#         test_dataset,
+#         optimizer,
+#         num_epochs=1,
+#         earlystop_patience=0,
+#         verbose=1,
+#         print_errors=0,
+#         obj_cost=model.cross_entropy,
+#         earlystop_cost_fn=model.f1_error,
+#         data_augmentation=model.default_data_augmentation,)
+#     pass

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -2,35 +2,37 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import tensorflow as tf
 import pytest
-from sklearn.preprocessing import FunctionTransformer
+from sklearn.preprocessing import FunctionTransformer, LabelBinarizer
 from sklearn.pipeline import make_pipeline
+from sklearn.datasets import load_digits
 from annsa.model_classes import DNN, dnn_model_features
+
 
 tf.enable_eager_execution()
 
-@pytest.fixture(params=[0.5, 0.999])
+@pytest.fixture(params=[(0.5, 1024),
+                        (0.5, 64), 
+                        (0.999, 1024)])
 def dnn(request):
     '''
     Constructs a dense neural network with dense connections
     initialized to ones.
     '''
-
-    dropout_probability = request.param
-
+    (dropout_probability, input_size) = request.param
     scaler = make_pipeline(FunctionTransformer(np.abs, validate=False))
     model_features = dnn_model_features(
-        learning_rate=1e-1,
+        learning_rate=1e-2,
         l2_regularization_scale=1e-1,
         dropout_probability=dropout_probability,
-        batch_size=2**5,
-        output_size=2,
+        batch_size=5,
+        output_size=3,
         dense_nodes=[10],
         output_function=None,
         activation_function=None,
         scaler=scaler)
     model = DNN(model_features)
     # forward pass to initialize dnn weights
-    model.forward_pass(np.ones([1, 1024]), training=False)
+    model.forward_pass(np.ones([1, input_size]), training=False)
     # set weights to ones
     weight_ones = []
     for index, weight in enumerate(model.get_weights()):
@@ -41,15 +43,29 @@ def dnn(request):
     model.set_weights(weight_ones)
     return model
 
+@pytest.fixture()
+def toy_dataset():
+    '''
+    Constructs toy dataset of digits.
+    '''
+    data, target = load_digits(n_class=3, return_X_y=True)
+    mlb = LabelBinarizer()
+    targets_binarized = mlb.fit_transform(target)
+    return (data, targets_binarized)
 
 # forward pass tests
+@pytest.mark.parametrize('dnn',
+                         ((0.5, 1024), (0.999, 1024)),
+                         indirect=True,)
 def test_forward_pass_0(dnn):
     '''case 0: Tests if output size is correct'''
     output = dnn.forward_pass(np.ones([1, 1024]), training=False)
-    assert(output.shape[1] == 2)
+    assert(output.shape[1] == 3)
 
 
-@pytest.mark.parametrize('dnn', [[]], indirect=True,)
+@pytest.mark.parametrize('dnn',
+                         ((0.5, 1024), (0.999, 1024)),
+                         indirect=True,)
 def test_forward_pass_1(dnn):
     '''case 1: Tests response to a spectrum of all ones
     when weight filters are all one. Note, layer before output has
@@ -61,11 +77,14 @@ def test_forward_pass_1(dnn):
 
 
 # loss function tests
+@pytest.mark.parametrize('dnn',
+                         ((0.5, 1024), (0.999, 1024)),
+                         indirect=True,)
 def test_loss_fn_0(dnn):
     '''case 0: tests if l2 regularization adds to loss_fn.'''
     loss = dnn.loss_fn(
         input_data=np.ones([1, 1024]),
-        targets=np.array([[16384, 16384]]),
+        targets=np.array([[16384, 16384, 16384]]),
         cost=dnn.mse,
         training=False)
     loss = loss
@@ -73,7 +92,9 @@ def test_loss_fn_0(dnn):
 
 
 # dropout tests
-@pytest.mark.parametrize('dnn', [0.999], indirect=True,)
+@pytest.mark.parametrize('dnn',
+                         ((0.999, 1024),),
+                         indirect=True,)
 def test_dropout_0(dnn):
     '''case 0: tests that dropout is applied when training.'''
     o_training_false = dnn.forward_pass(np.ones([1, 1024]),
@@ -83,7 +104,9 @@ def test_dropout_0(dnn):
     assert(np.array_equal(o_training_false, o_training_true) is False)
 
 
-@pytest.mark.parametrize('dnn', [0.999], indirect=True,)
+@pytest.mark.parametrize('dnn',
+                         ((0.999, 1024),),
+                         indirect=True,)
 def test_dropout_1(dnn):
     '''case 1: tests that dropout is not applied in inference, when training
     is False.'''
@@ -95,26 +118,22 @@ def test_dropout_1(dnn):
 
 
 # training tests
-@pytest.mark.parametrize('dnn', [0.5], indirect=True,)
-def test_training_0(dnn):
-    '''case 0: training on toy dataset reduces errors'''
-    
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+@pytest.mark.parametrize('cost', ['mse', 'cross_entropy'])
+@pytest.mark.parametrize('dnn',
+                         ((0.5, 64),),
+                         indirect=True,)
+def test_training_0(dnn, toy_dataset, cost):
+    '''case 0: test if training on toy dataset reduces errors using 
+    both error functions'''
+    (data, targets_binarized) = toy_dataset
+    cost_function = getattr(dnn, cost)
+    objective_cost, earlystop_cost = dnn.fit_batch(
+        (data, targets_binarized),
+        (data, targets_binarized),
+        optimizer=tf.train.AdamOptimizer(1e-2),
+        num_epochs=2,
+        obj_cost=cost_function,
+        data_augmentation=dnn.default_data_augmentation,)
+    epoch0_error = objective_cost['test'][0].numpy()
+    epoch1_error = objective_cost['test'][1].numpy()
+    assert(epoch1_error < epoch0_error)

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -35,8 +35,8 @@ def dnn(request):
     # forward pass to initialize dnn weights
     model.forward_pass(np.ones([1, input_size]), training=False)
     # set weights to ones
-    weight_ones = [np.ones(weight.shape) if (index % 2 == 0) else weight for index,
-                   weight in enumerate(model.get_weights())]
+    weight_ones = [np.ones(weight.shape) if (index % 2 == 0) else weight for
+                   index, weight in enumerate(model.get_weights())]
     model.set_weights(weight_ones)
     return model
 

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -28,7 +28,7 @@ def dnn(request):
         scaler=scaler)
     model = DNN(model_features)
     # forward pass to initialize dnn weights
-    model.forward_pass(1*np.ones([1, 1024]), training=False)
+    model.forward_pass(np.ones([1, 1024]), training=False)
     # set weights to ones
     weight_ones = []
     for index, weight in enumerate(model.get_weights()):
@@ -59,8 +59,8 @@ def test_forward_pass_1(dnn):
 
 
 # loss function tests
-def test_loss_fn_1(dnn):
-    '''case 1: tests if l2 regularization adds to loss_fn.'''
+def test_loss_fn_0(dnn):
+    '''case 0: tests if l2 regularization adds to loss_fn.'''
     loss = dnn.loss_fn(
         input_data=np.ones([1, 1024]),
         targets=np.array([[16384, 16384]]),

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -39,6 +39,7 @@ def dnn(request):
     model.set_weights(weight_ones)
     return model
 
+
 # forward pass tests
 def test_forward_pass_0(dnn):
     '''case 0: test if output size is correct'''
@@ -56,6 +57,7 @@ def test_forward_pass_1(dnn):
     output_value = output.numpy()[0][0]
     assert(output_value == 10240)
 
+
 # loss function tests
 def test_loss_fn_1(dnn):
     '''case 1: tests if l2 regularization adds to loss_fn.'''
@@ -67,20 +69,22 @@ def test_loss_fn_1(dnn):
     loss = loss
     assert(loss > 0.)
 
+
 # dropout test
 def test_dropout_0(dnn):
     '''case 0: tests that dropout is applied when training.'''
     o_training_false = dnn.forward_pass(np.ones([1, 1024]),
-                                          training=False).numpy()
+                                        training=False).numpy()
     o_training_true = dnn.forward_pass(np.ones([1, 1024]),
-                                         training=True).numpy()
+                                       training=True).numpy()
     assert(np.array_equal(o_training_false, o_training_true) is False)
 
 
 def test_dropout_1(dnn):
-    '''case 1: tests that dropout is not applied in inference, when training is False.'''
+    '''case 1: tests that dropout is not applied in inference, when training
+    is False.'''
     o_training_false_1 = dnn.forward_pass(np.ones([1, 1024]),
                                           training=False).numpy()
     o_training_false_2 = dnn.forward_pass(np.ones([1, 1024]),
-                                         training=False).numpy()
+                                          training=False).numpy()
     assert(np.array_equal(o_training_false_1, o_training_false_2))

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -35,12 +35,8 @@ def dnn(request):
     # forward pass to initialize dnn weights
     model.forward_pass(np.ones([1, input_size]), training=False)
     # set weights to ones
-    weight_ones = []
-    for index, weight in enumerate(model.get_weights()):
-        if index % 2 == 0:
-            weight_ones.append(np.ones(weight.shape))
-        else:
-            weight_ones.append(weight)
+    weight_ones = [np.ones(weight.shape) if (index % 2 == 0) else weight for index,
+                   weight in enumerate(model.get_weights())]
     model.set_weights(weight_ones)
     return model
 

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -10,9 +10,10 @@ from annsa.model_classes import DNN, dnn_model_features
 
 tf.enable_eager_execution()
 
+
 @pytest.fixture(params=[(0.5, 1024),
-                        (0.5, 64), 
-                        (0.999, 1024)])
+                        (0.5, 64),
+                        (0.999, 1024), ])
 def dnn(request):
     '''
     Constructs a dense neural network with dense connections
@@ -43,6 +44,7 @@ def dnn(request):
     model.set_weights(weight_ones)
     return model
 
+
 @pytest.fixture()
 def toy_dataset():
     '''
@@ -52,6 +54,7 @@ def toy_dataset():
     mlb = LabelBinarizer()
     targets_binarized = mlb.fit_transform(target)
     return (data, targets_binarized)
+
 
 # forward pass tests
 @pytest.mark.parametrize('dnn',
@@ -123,7 +126,7 @@ def test_dropout_1(dnn):
                          ((0.5, 64),),
                          indirect=True,)
 def test_training_0(dnn, toy_dataset, cost):
-    '''case 0: test if training on toy dataset reduces errors using 
+    '''case 0: test if training on toy dataset reduces errors using
     both error functions'''
     (data, targets_binarized) = toy_dataset
     cost_function = getattr(dnn, cost)

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -42,7 +42,7 @@ def dnn(request):
 
 # forward pass tests
 def test_forward_pass_0(dnn):
-    '''case 0: test if output size is correct'''
+    '''case 0: Tests if output size is correct'''
     output = dnn.forward_pass(np.ones([1, 1024]), training=False)
     assert(output.shape[1] == 2)
 

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -19,7 +19,7 @@ def dnn(request):
     model_features = dnn_model_features(
         learning_rate=1e-1,
         l2_regularization_scale=1e-1,
-        dropout_probability=0.5,
+        dropout_probability=0.999,
         batch_size=2**5,
         output_size=2,
         dense_nodes=[10],

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -47,7 +47,6 @@ def test_forward_pass_0(dnn):
     assert(output.shape[1] == 2)
 
 
-@pytest.mark.parametrize('dnn', [[]], indirect=True,)
 def test_forward_pass_1(dnn):
     '''case 1: Tests response to a spectrum of all ones
     when weight filters are all one. Note, layer before output has

--- a/annsa/tests/test_training_dnn.py
+++ b/annsa/tests/test_training_dnn.py
@@ -10,6 +10,37 @@ tf.enable_eager_execution()
 
 
 @pytest.fixture()
+def dnn():
+    '''
+    Constructs a dense neural network with dense connections
+    initialized to ones.
+    '''
+    scaler = make_pipeline(FunctionTransformer(np.abs, validate=False))
+    model_features = dnn_model_features(
+        learning_rate=1e-1,
+        l2_regularization_scale=1e-1,
+        dropout_probability=0.999,
+        batch_size=2**5,
+        output_size=2,
+        dense_nodes=[10],
+        output_function=None,
+        activation_function=None,
+        scaler=scaler)
+    model = DNN(model_features)
+    # forward pass to initialize dnn weights
+    model.forward_pass(np.ones([1, 1024]), training=False)
+    # set weights to ones
+    weight_ones = []
+    for index, weight in enumerate(model.get_weights()):
+        if index % 2 == 0:
+            weight_ones.append(np.ones(weight.shape))
+        else:
+            weight_ones.append(weight)
+    model.set_weights(weight_ones)
+    return model
+
+
+@pytest.fixture()
 def dnn(request):
     '''
     Constructs a dense neural network with dense connections
@@ -47,6 +78,7 @@ def test_forward_pass_0(dnn):
     assert(output.shape[1] == 2)
 
 
+@pytest.mark.parametrize('dnn', [[]], indirect=True,)
 def test_forward_pass_1(dnn):
     '''case 1: Tests response to a spectrum of all ones
     when weight filters are all one. Note, layer before output has
@@ -69,7 +101,7 @@ def test_loss_fn_0(dnn):
     assert(loss > 0.)
 
 
-# dropout test
+# dropout tests
 def test_dropout_0(dnn):
     '''case 0: tests that dropout is applied when training.'''
     o_training_false = dnn.forward_pass(np.ones([1, 1024]),
@@ -87,3 +119,28 @@ def test_dropout_1(dnn):
     o_training_false_2 = dnn.forward_pass(np.ones([1, 1024]),
                                           training=False).numpy()
     assert(np.array_equal(o_training_false_1, o_training_false_2))
+
+
+# training tests
+def test_training_0(dnn):
+    '''case 0: training on toy dataset reduces errors'''
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This PR updates the CNN and DNN unit tests for the Tensorflow classes in the `model_classes.py` module. Tests use fixtures to create models with dense connections and convolutional filters of all ones. Training tests and tests for the CAE and DAE to come.

Tests include checking if:
- dropout changes network output when applied (during training)
- dropout changes network output when not applied (during inference)
- l2 regularization adds to the cost function
- output values to unit inputs (inputs of all ones) make sense